### PR TITLE
Workaround when using WSL container to upgrade TTY shell

### DIFF
--- a/docs/cheatsheets/shell-reverse-cheatsheet.md
+++ b/docs/cheatsheets/shell-reverse-cheatsheet.md
@@ -555,6 +555,20 @@ export TERM=xterm-256color
 stty rows <num> columns <cols>
 ```
 
+:warning: With Windows Terminal + WSL container,  `[CTRL] + [Z]` can get you out of / freeze the container.
+To overcome this issue, run `nc` in a `tmux`, and send a `SIGTSTP` signal to the `nc` process.
+
+```bash
+# Create a new window in tmux
+## <ctrl+b> then <c>
+
+# Find the PID of the nc process (column PID)
+ps aux # | grep -i nc | grep -vi grep
+
+# Send a SIGTSTP (ctrl+z) signal to the process
+kill -s TSTP <PID>
+```
+
 or use `socat` binary to get a fully tty reverse shell
 
 ```bash

--- a/docs/cheatsheets/shell-reverse-cheatsheet.md
+++ b/docs/cheatsheets/shell-reverse-cheatsheet.md
@@ -559,8 +559,14 @@ stty rows <num> columns <cols>
 To overcome this issue, run `nc` in a `tmux`, and send a `SIGTSTP` signal to the `nc` process.
 
 ```bash
+# Enter in tmux
+tmux
+
+# Do your netcat stuff ...
+nc -lnvp 4242
+
 # Create a new window in tmux
-## <ctrl+b> then <c>
+ctrl+b c
 
 # Find the PID of the nc process (column PID)
 ps aux # | grep -i nc | grep -vi grep


### PR DESCRIPTION
Hello,

I am used to hack using [Exegol](https://github.com/ThePorgs/Exegol) on my Windows computer, using Windows Terminal. I was used to the fact that I couldn't upgrade to TTY shell because `[CTRL] + [Z]` leaves the Exegol container.

But I thought about a solution, and it worked, so I share it, just in case there are other users in the same case !