### PR TITLE
Fix Markdown Rendering Issue in Windows Privilege Escalation - User Enumeration

### DIFF
--- a/docs/redteam/escalation/windows-privilege-escalation.md
+++ b/docs/redteam/escalation/windows-privilege-escalation.md
@@ -175,7 +175,8 @@ Get-ChildItem C:\Users -Force | select Name
 
 List logon requirements; useable for bruteforcing
 
-```powershell$env:usernadsc
+```powershell
+$env:usernadsc
 net accounts
 ```
 


### PR DESCRIPTION
While browsing the [Windows Privilege Escalation](https://swisskyrepo.github.io/InternalAllTheThings/redteam/escalation/windows-privilege-escalation/#user-enumeration) page, I noticed that there was a rendering error in the `User Enumeration` section (specifically the `List logon requirements` part) that was being caused by a missing new line (pictured below). 

![rendering-error](https://github.com/user-attachments/assets/db9f4c90-c387-4f15-9ab4-15d9ef714ee1)

This issue was preventing the commands in the affected section from showing on the page properly. This PR adds in the required new line. 