### PR TITLE
Update aws-ioc-detection.md

### DIFF
--- a/docs/cloud/aws/aws-ioc-detection.md
+++ b/docs/cloud/aws/aws-ioc-detection.md
@@ -26,7 +26,7 @@ aws cloudtrail update-trail --name cloudgoat_trail --no-include-global-service-e
 
 :warning: When using awscli on Kali Linux, Pentoo and Parrot Linux, a log is generated based on the user-agent.
 
-Pacu bypass this problem by defining a custom User-Agent: [pacu.py#L1473](https://web.archive.org/web/20201111195614/https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu.py#L1473) (note: check the lines in the area of L1300)
+Pacu bypass this problem by defining a custom User-Agent: [pacu.py#L1473](https://web.archive.org/web/20201111195614/https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu.py#L1303) 
 
 ```python
 boto3_session = boto3.session.Session()

--- a/docs/cloud/aws/aws-ioc-detection.md
+++ b/docs/cloud/aws/aws-ioc-detection.md
@@ -26,7 +26,7 @@ aws cloudtrail update-trail --name cloudgoat_trail --no-include-global-service-e
 
 :warning: When using awscli on Kali Linux, Pentoo and Parrot Linux, a log is generated based on the user-agent.
 
-Pacu bypass this problem by defining a custom User-Agent: [pacu.py#L1473](https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu.py#L1473)
+Pacu bypass this problem by defining a custom User-Agent: [pacu.py#L1473](https://web.archive.org/web/20201111195614/https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu.py#L1473) (note: check the lines in the area of L1300)
 
 ```python
 boto3_session = boto3.session.Session()


### PR DESCRIPTION
Hi,

**Changes**
- Fix pacu.py link and add a note about the code's line.

As there is no `issues` tab, a short description about the problem.

**Repro steps:**
1. Visit https://swisskyrepo.github.io/InternalAllTheThings/cloud/aws/aws-ioc-detection/#os-user-agent or https://github.com/swisskyrepo/InternalAllTheThings/blob/main/docs/cloud/aws/aws-ioc-detection.md
2. Scroll down and check given link from `Pacu bypass this problem by defining a custom User-Agent: [pacu.py#L1473](https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu.py#L1473)`

**Description** 
The issue is, there is `404 error` site at this moment.

I've checked with the Wayback Machine, and updated the link to proper one. 
I've also checked mentioned lines of code, so added a short note about other possible place.

The problem with specifying a line of code is that as the product is further developed, it can change over time - `web.archive.org` solves this problem a little bit.

Thanks to this solution, there is still access to part of the mentioned code.

Please let me know if something to change.

Best wishes,